### PR TITLE
Some improvements

### DIFF
--- a/Test.php
+++ b/Test.php
@@ -2,27 +2,27 @@
 
 include('CashAddress.php');
 
-$p2pk = '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa';
 $p2pkh = '12higDjoCCNXSA95xZMWUdPvXNmkAduhWv';
 $p2sh = '342ftSRCvFHfCeFFBuz4xwbeqnDw6BGUey';
-
-echo "\nTest P2PK addresses\n\n";
-
-echo "Old ({$p2pk}) to new: " . ($r = \CashAddress\CashAddress::old2new($p2pk)) . "\n";
-echo "New ({$r}) to old: " . ($r = \CashAddress\CashAddress::new2old($r)) . "\n";
-assert(($p2pk == $r), 'Whoops');
-echo "Ok. \n";
+$malformed = 'bitcoincash:qpm2qsznhks23z7629mas6s4cwzf74vcwvy22gdx6a';
 
 echo "\nTest P2PKH addresses\n\n";
 
 echo "Old ({$p2pkh}) to new: " . ($r = \CashAddress\CashAddress::old2new($p2pkh)) . "\n";
-echo "New ({$r}) to old: " . ($r = \CashAddress\CashAddress::new2old($r)) . "\n";
+echo "New ({$r}) to old: " . ($r = \CashAddress\CashAddress::new2old($r, false)) . "\n";
 assert(($p2pkh == $r),'Whoops');
 echo "Ok. \n";
 
 echo "\nTest P2SH addresses\n\n";
 
 echo "Old ({$p2sh}) to new: " . ($r = \CashAddress\CashAddress::old2new($p2sh)) . "\n";
-echo "New ({$r}) to old: " . ($r = \CashAddress\CashAddress::new2old($r)) . "\n";
+echo "New ({$r}) to old: " . ($r = \CashAddress\CashAddress::new2old($r, false)) . "\n";
 assert(($p2sh == $r), 'Whoops');
+echo "Ok. \n\n";
+
+echo "\nTest error correction\n\n";
+
+echo "Malformed ({$malformed}) to old: " . ($r = \CashAddress\CashAddress::new2old($malformed, true)) . "\n";
+echo "Malformed ({$malformed}) error correction: " . ($r = \CashAddress\CashAddress::fixCashAddrErrors($malformed)) . "\n";
+assert(("bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a" == $r), 'Whoops');
 echo "Ok. \n\n";


### PR DESCRIPTION
- Correcting malformed addresses shouldn't be done while decoding.
- There's no need to check for ~~P2PK~~ and P2PKH addresses, they're both consisting of a version byte, a hash, a checksum. The difference becomes exposed when coins are spend from those addresses, which is not needed while translating addresses.

P2PK address doesn't exist. It is pay to uncompressed public key.

~uMCCCS' GitHub account
  