### PR TITLE
Add support for eCash address

### DIFF
--- a/Test.php
+++ b/Test.php
@@ -56,3 +56,110 @@ echo "Old testnet ({$testnetp2sh}) to new: " . ($r = \CashAddress\CashAddress::o
 echo "New ({$r}) to old: " . ($r = \CashAddress\CashAddress::new2old($r, false)) . "\n";
 assert(($testnetp2sh == $r), 'Whoops');
 echo "Ok. \n\n";
+
+echo "\nTest prefix detection\n\n";
+
+$address = "qq7h7thq7seggqawtnlus5f2k62m7l07vud66vg4ge";
+echo "Prefix for " . $address . " is: " . ($r = \CashAddress\CashAddress::getPrefix($address)) . "\n";
+assert(($r === "ecash"), 'Whoops');
+echo "Ok. \n\n";
+
+$address = "qq7h7thq7seggqawtnlus5f2k62m7l07vu5hw8n0ww";
+echo "Prefix for " . $address . " is: " . ($r = \CashAddress\CashAddress::getPrefix($address)) . "\n";
+assert(($r === "bitcoincash"), 'Whoops');
+echo "Ok. \n\n";
+
+$address = "qrfekq9s0c8tcuh75wpcxqnyl5e7dhqk4gq6pjct44";
+echo "Prefix for " . $address . " is: " . ($r = \CashAddress\CashAddress::getPrefix($address)) . "\n";
+assert(($r === "ectest"), 'Whoops');
+echo "Ok. \n\n";
+
+$address = "qrfekq9s0c8tcuh75wpcxqnyl5e7dhqk4gmw07xth0";
+echo "Prefix for " . $address . " is: " . ($r = \CashAddress\CashAddress::getPrefix($address)) . "\n";
+assert(($r === "bchtest"), 'Whoops');
+echo "Ok. \n\n";
+
+echo "\nTest BCH to eCash address conversion\n\n";
+
+$bch_p2pkh = "bitcoincash:qzvmc7962aaftgglrg6y6nf2u40jlptmnqhpeu5t83";
+echo "eCash converted address for " . $bch_p2pkh . " is: " . ($r = \CashAddress\CashAddress::bch2xec($bch_p2pkh)) . "\n";
+assert(($r === "ecash:qzvmc7962aaftgglrg6y6nf2u40jlptmnqwvdh03px"), 'Whoops');
+echo "Ok. \n\n";
+
+$bch_p2pkh_noPrefix = "qzvmc7962aaftgglrg6y6nf2u40jlptmnqhpeu5t83";
+echo "eCash converted address for " . $bch_p2pkh_noPrefix . " is: " . ($r = \CashAddress\CashAddress::bch2xec($bch_p2pkh_noPrefix)) . "\n";
+assert(($r === "ecash:qzvmc7962aaftgglrg6y6nf2u40jlptmnqwvdh03px"), 'Whoops');
+echo "Ok. \n\n";
+
+$bch_p2sh = "bitcoincash:pqv60krfqv3k3lglrcnwtee6ftgwgaykpccr8hujjz";
+echo "eCash converted address for " . $bch_p2sh . " is: " . ($r = \CashAddress\CashAddress::bch2xec($bch_p2sh)) . "\n";
+assert(($r === "ecash:pqv60krfqv3k3lglrcnwtee6ftgwgaykpcpwnu8g54"), 'Whoops');
+echo "Ok. \n\n";
+
+$bch_bitpayp2pkh = "bitcoincash:qzvmc7962aaftgglrg6y6nf2u40jlptmnqhpeu5t83";
+echo "eCash converted address for " . $bch_bitpayp2pkh . " is: " . ($r = \CashAddress\CashAddress::bch2xec($bch_bitpayp2pkh)) . "\n";
+assert(($r === "ecash:qzvmc7962aaftgglrg6y6nf2u40jlptmnqwvdh03px"), 'Whoops');
+echo "Ok. \n\n";
+
+$bch_bitpayp2sh = "bitcoincash:pp7xwa0zpclf8rfd06whntp3qyyt55qamvfsugp2zx";
+echo "eCash converted address for " . $bch_bitpayp2sh . " is: " . ($r = \CashAddress\CashAddress::bch2xec($bch_bitpayp2sh)) . "\n";
+assert(($r === "ecash:pp7xwa0zpclf8rfd06whntp3qyyt55qamvsagr6sy3"), 'Whoops');
+echo "Ok. \n\n";
+
+$bch_testnetp2pkh = "bchtest:qqjr7yu573z4faxw8ltgvjwpntwys08fysk07zmvce";
+echo "eCash converted address for " . $bch_testnetp2pkh . " is: " . ($r = \CashAddress\CashAddress::bch2xec($bch_testnetp2pkh)) . "\n";
+assert(($r === "ectest:qqjr7yu573z4faxw8ltgvjwpntwys08fysdmsw9v6r"), 'Whoops');
+echo "Ok. \n\n";
+
+$bch_testnetp2pkh_noPrefix = "qqjr7yu573z4faxw8ltgvjwpntwys08fysk07zmvce";
+echo "eCash converted address for " . $bch_testnetp2pkh_noPrefix . " is: " . ($r = \CashAddress\CashAddress::bch2xec($bch_testnetp2pkh_noPrefix)) . "\n";
+assert(($r === "ectest:qqjr7yu573z4faxw8ltgvjwpntwys08fysdmsw9v6r"), 'Whoops');
+echo "Ok. \n\n";
+
+$bch_testnetp2sh= "bchtest:pp8f7ww2g6y07ypp9r4yendrgyznysc9kqxh6acwu3";
+echo "eCash converted address for " . $bch_testnetp2sh . " is: " . ($r = \CashAddress\CashAddress::bch2xec($bch_testnetp2sh)) . "\n";
+assert(($r === "ectest:pp8f7ww2g6y07ypp9r4yendrgyznysc9kqar53xw7t"), 'Whoops');
+echo "Ok. \n\n";
+
+echo "\nTest eCash to BCH address conversion\n\n";
+
+$xec_p2pkh = "ecash:qzvmc7962aaftgglrg6y6nf2u40jlptmnqwvdh03px";
+echo "eCash converted address for " . $xec_p2pkh . " is: " . ($r = \CashAddress\CashAddress::xec2bch($xec_p2pkh)) . "\n";
+assert(($r === "bitcoincash:qzvmc7962aaftgglrg6y6nf2u40jlptmnqhpeu5t83"), 'Whoops');
+echo "Ok. \n\n";
+
+$xec_p2pkh_noPrefix = "qzvmc7962aaftgglrg6y6nf2u40jlptmnqwvdh03px";
+echo "eCash converted address for " . $xec_p2pkh_noPrefix . " is: " . ($r = \CashAddress\CashAddress::xec2bch($xec_p2pkh_noPrefix)) . "\n";
+assert(($r === "bitcoincash:qzvmc7962aaftgglrg6y6nf2u40jlptmnqhpeu5t83"), 'Whoops');
+echo "Ok. \n\n";
+
+$xec_p2sh = "ecash:pqv60krfqv3k3lglrcnwtee6ftgwgaykpcpwnu8g54";
+echo "eCash converted address for " . $xec_p2sh . " is: " . ($r = \CashAddress\CashAddress::xec2bch($xec_p2sh)) . "\n";
+assert(($r === "bitcoincash:pqv60krfqv3k3lglrcnwtee6ftgwgaykpccr8hujjz"), 'Whoops');
+echo "Ok. \n\n";
+
+$xec_bitpayp2pkh = "ecash:qzvmc7962aaftgglrg6y6nf2u40jlptmnqwvdh03px";
+echo "eCash converted address for " . $xec_bitpayp2pkh . " is: " . ($r = \CashAddress\CashAddress::xec2bch($xec_bitpayp2pkh)) . "\n";
+assert(($r === "bitcoincash:qzvmc7962aaftgglrg6y6nf2u40jlptmnqhpeu5t83"), 'Whoops');
+echo "Ok. \n\n";
+
+$xec_bitpayp2sh = "ecash:pp7xwa0zpclf8rfd06whntp3qyyt55qamvsagr6sy3";
+echo "eCash converted address for " . $xec_bitpayp2sh . " is: " . ($r = \CashAddress\CashAddress::xec2bch($xec_bitpayp2sh)) . "\n";
+assert(($r === "bitcoincash:pp7xwa0zpclf8rfd06whntp3qyyt55qamvfsugp2zx"), 'Whoops');
+echo "Ok. \n\n";
+
+$xec_testnetp2pkh = "ectest:qqjr7yu573z4faxw8ltgvjwpntwys08fysdmsw9v6r";
+echo "eCash converted address for " . $xec_testnetp2pkh . " is: " . ($r = \CashAddress\CashAddress::xec2bch($xec_testnetp2pkh)) . "\n";
+assert(($r === "bchtest:qqjr7yu573z4faxw8ltgvjwpntwys08fysk07zmvce"), 'Whoops');
+echo "Ok. \n\n";
+
+$xec_testnetp2pkh_noPrefix = "qqjr7yu573z4faxw8ltgvjwpntwys08fysdmsw9v6r";
+echo "eCash converted address for " . $xec_testnetp2pkh_noPrefix . " is: " . ($r = \CashAddress\CashAddress::xec2bch($xec_testnetp2pkh_noPrefix)) . "\n";
+assert(($r === "bchtest:qqjr7yu573z4faxw8ltgvjwpntwys08fysk07zmvce"), 'Whoops');
+echo "Ok. \n\n";
+
+$xec_testnetp2sh= "ectest:pp8f7ww2g6y07ypp9r4yendrgyznysc9kqar53xw7t";
+echo "eCash converted address for " . $xec_testnetp2sh . " is: " . ($r = \CashAddress\CashAddress::xec2bch($xec_testnetp2sh)) . "\n";
+assert(($r === "bchtest:pp8f7ww2g6y07ypp9r4yendrgyznysc9kqxh6acwu3"), 'Whoops');
+echo "Ok. \n\n";
+


### PR DESCRIPTION
This adds 3 new public methods:
 - `getPrefix()` tries to retrieve the prefix from a cash address
 - `xec2bch()` and `bch2xec()` convert the address between eCash and BCH formats